### PR TITLE
US06 – Autenticação de Usuários | Task 6.3

### DIFF
--- a/app/controllers/BookController.php
+++ b/app/controllers/BookController.php
@@ -58,6 +58,7 @@ class BookController extends RenderView
 
     public function borrowBook($id)
     {
+        $this->requireAuth('user');
         $bookModel = new BookModel();
         $success = $bookModel->borrowBook($id);
 
@@ -73,6 +74,7 @@ class BookController extends RenderView
 
     public function returnBook($id)
     {
+        $this->requireAuth('user');
         $bookModel = new BookModel();
         $success = $bookModel->returnBook($id);
 

--- a/app/router/routes.php
+++ b/app/router/routes.php
@@ -1,17 +1,19 @@
 <?php
 
-$routes = [
+
+$userRoutes = [
     "/" => "BookController@listBooks",
     "/search" => "BookController@searchBooks",
     "/borrow/{id}" => "BookController@borrowBook",
     "/return/{id}" => "BookController@returnBook",
     "/details/{id}" => "BookController@viewBookDetails",
-
-    
     "/api/auth/register" => "AuthController@register",
     "/api/auth/login" => "AuthController@login",
     "/api/auth/logout" => "AuthController@logout",
     "/api/auth/me" => "AuthController@me",
+];
 
+$adminRoutes = [
+    ...$userRoutes,
     "/api/books" => "BookController@createBook",
 ];

--- a/docs/controle-de-perfis-e-rotas.md
+++ b/docs/controle-de-perfis-e-rotas.md
@@ -1,0 +1,25 @@
+# Controle de Perfis e Rotas
+
+## O que mudou?
+
+O sistema agora separa as rotas acessíveis para usuários comuns e administradores, garantindo que cada perfil só acesse as funcionalidades permitidas.
+
+### 1. Separação das rotas
+- No arquivo `app/router/routes.php`, foram criados dois arrays:
+  - `$userRoutes`: contém apenas as rotas acessíveis para usuários comuns.
+  - `$adminRoutes`: inclui todas as rotas de usuário e adiciona rotas exclusivas de administrador (ex: criação de livros).
+
+### 2. Seleção dinâmica das rotas
+- No arquivo `index.php`, o sistema verifica o perfil do usuário logado (campo `role` na sessão):
+  - Se for `admin`, utiliza `$adminRoutes`.
+  - Caso contrário, utiliza `$userRoutes`.
+- O roteador (`Core`) recebe apenas as rotas permitidas para o perfil atual.
+
+### 3. Benefícios
+- Usuários comuns não conseguem acessar rotas administrativas.
+- Administradores têm acesso total às funcionalidades do sistema.
+- O controle é feito de forma centralizada e fácil de manter.
+
+---
+
+Se precisar de mais detalhes sobre como expandir ou customizar os perfis, consulte este documento ou peça suporte!

--- a/index.php
+++ b/index.php
@@ -29,5 +29,9 @@ spl_autoload_register(function ($file) {
     }
 });
 
-$core = new Core($routes);
+$isAdmin = isset($_SESSION['user']) && isset($_SESSION['user']['role']) && $_SESSION['user']['role'] === 'admin';
+
+$activeRoutes = $isAdmin ? $adminRoutes : $userRoutes;
+
+$core = new Core($activeRoutes);
 $core->run();


### PR DESCRIPTION
# Controle de Perfis e Rotas

## O que mudou?

O sistema agora separa as rotas acessíveis para usuários comuns e administradores, garantindo que cada perfil só acesse as funcionalidades permitidas.

### 1. Separação das rotas
- No arquivo `app/router/routes.php`, foram criados dois arrays:
  - `$userRoutes`: contém apenas as rotas acessíveis para usuários comuns.
  - `$adminRoutes`: inclui todas as rotas de usuário e adiciona rotas exclusivas de administrador (ex: criação de livros).

### 2. Seleção dinâmica das rotas
- No arquivo `index.php`, o sistema verifica o perfil do usuário logado (campo `role` na sessão):
  - Se for `admin`, utiliza `$adminRoutes`.
  - Caso contrário, utiliza `$userRoutes`.
- O roteador (`Core`) recebe apenas as rotas permitidas para o perfil atual.