### PR TITLE
fix: borrow and return error

### DIFF
--- a/app/models/BorrowModel.php
+++ b/app/models/BorrowModel.php
@@ -57,7 +57,7 @@ class BorrowModel extends Database
                 ':book_id' => $bookId,
                 ':borrowed_at' => $borrowedAt->format('Y-m-d H:i:s'),
                 ':due_date' => $dueDate->format('Y-m-d'),
-                ':status' => 'Emprestado'
+                ':status' => 'borrowed'
             ]);
 
             $updateBook = $this->pdo->prepare(
@@ -99,13 +99,13 @@ class BorrowModel extends Database
             $this->pdo->beginTransaction();
 
             $borrowStmt = $this->pdo->prepare(
-                "SELECT id, status FROM Borrows
-                 WHERE book_id = :book_id
-                   AND user_id = :user_id
-                   AND status IN ('Emprestado', 'Atrasado')
-                 ORDER BY borrowed_at DESC
-                 LIMIT 1
-                 FOR UPDATE"
+                                "SELECT id, status FROM Borrows
+                                 WHERE book_id = :book_id
+                                     AND user_id = :user_id
+                                     AND status IN ('borrowed', 'late')
+                                 ORDER BY borrowed_at DESC
+                                 LIMIT 1
+                                 FOR UPDATE"
             );
             $borrowStmt->execute([
                 ':book_id' => $bookId,
@@ -129,7 +129,7 @@ class BorrowModel extends Database
             );
             $updateBorrow->execute([
                 ':returned_at' => $returnedAt->format('Y-m-d H:i:s'),
-                ':status' => 'Devolvido',
+                ':status' => 'returned',
                 ':id' => $borrow['id'],
             ]);
 
@@ -196,9 +196,9 @@ class BorrowModel extends Database
     {
         try {
             $stmt = $this->pdo->prepare(
-                "SELECT book_id FROM Borrows
-                 WHERE user_id = :user_id
-                   AND status IN ('Emprestado', 'Atrasado')"
+                                "SELECT book_id FROM Borrows
+                                 WHERE user_id = :user_id
+                                     AND status IN ('borrowed', 'late')"
             );
             $stmt->execute([':user_id' => $userId]);
             $ids = $stmt->fetchAll(PDO::FETCH_COLUMN);

--- a/docs/localdocs/borrow-error-explanation.md
+++ b/docs/localdocs/borrow-error-explanation.md
@@ -1,0 +1,19 @@
+## Erro: "Não foi possível registrar o empréstimo no momento."
+
+Breve e direto: o servidor respondeu com a mensagem genérica porque o banco rejeitou a operação.
+
+- Causa: tentamos gravar valores em português (ex.: `Emprestado`, `Devolvido`) no campo `status` da tabela `Borrows`, mas o ENUM do banco foi definido em inglês: `('borrowed','returned','late')`. O MySQL não adivinha sinônimos, ele só aceita os valores exatos.
+- O que foi feito: `BorrowModel.php` foi ajustado para usar os valores do enum (`'borrowed'` ao criar; `'returned'` ao devolver; consultas usam `'borrowed'/'late'`).
+
+Teste rápido:
+
+1. Reinicie o servidor/contêiner ou o processo PHP para carregar a alteração.
+2. Faça a requisição POST para `/borrow/{id}` (usar a UI é suficiente) — deve retornar JSON com `success: true`.
+3. Se ainda falhar, verifique os logs do PHP (error_log) — a mensagem de erro do PDO foi registrada lá com detalhes.
+
+Opções alternativas (se preferir guardar tudo em português):
+
+- Alterar o ENUM no banco para aceitar os rótulos em português e migrar os valores existentes (mais invasivo).
+- Ou manter o padrão atual (recomendado) e garantir que todas as gravações usem os valores do enum.
+
+Observação final: sim, o MySQL é literal — e agora o código também.


### PR DESCRIPTION
## Erro: "Não foi possível registrar o empréstimo no momento."

Breve e direto: o servidor respondeu com a mensagem genérica porque o banco rejeitou a operação.

- Causa: tentamos gravar valores em português (ex.: `Emprestado`, `Devolvido`) no campo `status` da tabela `Borrows`, mas o ENUM do banco foi definido em inglês: `('borrowed','returned','late')`. O MySQL não adivinha sinônimos, ele só aceita os valores exatos.
- O que foi feito: `BorrowModel.php` foi ajustado para usar os valores do enum (`'borrowed'` ao criar; `'returned'` ao devolver; consultas usam `'borrowed'/'late'`).

Teste rápido:

1. Reinicie o servidor/contêiner ou o processo PHP para carregar a alteração.
2. Faça a requisição POST para `/borrow/{id}` (usar a UI é suficiente) — deve retornar JSON com `success: true`.
3. Se ainda falhar, verifique os logs do PHP (error_log) — a mensagem de erro do PDO foi registrada lá com detalhes.

